### PR TITLE
Add http caching to categories endpoint

### DIFF
--- a/app/controllers/api/v1/connect/categories_controller.rb
+++ b/app/controllers/api/v1/connect/categories_controller.rb
@@ -5,13 +5,9 @@ module Api
     module Connect
       class CategoriesController < ApplicationController
         def index
-          render json: categories
-        end
-
-        private
-
-        def categories
-          @categories ||= Rails.application.config_for(:connect_categories)
+          if stale?(etag: CONNECT_CATEGORIES, last_modified: CONNECT_CATEGORIES_LAST_MODIFIED, public: true)
+            render json: CONNECT_CATEGORIES
+          end
         end
       end
     end

--- a/config/initializers/connect_categories.rb
+++ b/config/initializers/connect_categories.rb
@@ -1,0 +1,5 @@
+# Load categories for the /connect/categories endpoint and store it in a
+# constant so we only load the file once instead of every request.
+CONNECT_CATEGORIES = Rails.application.config_for(:connect_categories).freeze
+
+CONNECT_CATEGORIES_LAST_MODIFIED = Time.zone.now

--- a/test/controllers/api/v1/connect/categories_controller_test.rb
+++ b/test/controllers/api/v1/connect/categories_controller_test.rb
@@ -8,4 +8,30 @@ class Api::V1::Connect::CategoriesControllerTest < ActionDispatch::IntegrationTe
     categories = Rails.application.config_for(:connect_categories)
     assert_equal json, categories
   end
+
+  test "Respects If-Modified-Since headers" do
+    get api_v1_connect_categories_path, headers: {
+      "If-Modified-Since" => Time.now.rfc2822
+    }
+    assert_response 304
+
+    get api_v1_connect_categories_path, headers: {
+      "If-Modified-Since" => 2.days.ago.rfc2822
+    }
+    assert_response 200
+  end
+
+  test "Respects If-None-Match headers" do
+    get api_v1_connect_categories_path, headers: {
+      "If-None-Match" => 'nope'
+    }
+    etag = response.headers["ETag"]
+    assert_not_nil etag, "Should have returned an etag"
+    assert_response 200
+
+    get api_v1_connect_categories_path, headers: {
+      "If-None-Match" => etag
+    }
+    assert_response 304
+  end
 end


### PR DESCRIPTION
also cached the categories structure so that it is only loaded once
instead of on every request.